### PR TITLE
Specify requirements versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-undetected-chromedriver
+undetected-chromedriver==3.4.5
+selenium==4.9.1
 markdownify


### PR DESCRIPTION
We must clearly define the versions in the requirements.txt file.
An update to the undetected_chromedriver (3.5.0), was released yesterday, which interferes with our current method of reading network logs (used in the `get_conversation_id()` function).

On version 3.5.0, we encounter this error:
`
selenium.common.exceptions.InvalidArgumentException: Message: invalid argument: log type 'performance' not found
`

Furthermore, we should also define the selenium version. If we upgrade to the newly released version 4.10 (June 7), we encounter this error:
`
TypeError: WebDriver.__init__() got an unexpected keyword argument 'executable_path'
`

Of course, upgrading both packages to their latest versions is preferable. However, I'm currently unable to invest time to implement everything for that.

I have updated the requirements.txt as follows:
undetected_chromedriver -> 3.4.5
selenium -> 4.9.1 (this might be unnecessary, issue #11 provides a solution.)