### PR TITLE
fix:add info_buttons xpath to pass through popup window

### DIFF
--- a/src/UnlimitedGPT/internal/chatgpt_data.py
+++ b/src/UnlimitedGPT/internal/chatgpt_data.py
@@ -15,6 +15,9 @@ class ChatGPTVariables:
 
     # Popups and such
     info_buttons = (
+        (By.XPATH, '//*[@id="radix-:rg:"]/div[2]/div[1]/div[2]/button'),
+        (By.XPATH, '//*[@id="radix-:rg:"]/div[2]/div[1]/div[2]/button[2]'),
+        (By.XPATH, '//*[@id="radix-:rg:"]/div[2]/div[1]/div[2]/button[2]'),
         (By.XPATH, "/html/body/div[3]/div/div/div/div[2]/div/div[2]/button"),
         (By.XPATH, "/html/body/div[3]/div/div/div/div[2]/div/div[2]/button[2]"),
         (By.XPATH, "/html/body/div[3]/div/div/div/div[2]/div/div[2]/button[2]"),


### PR DESCRIPTION
The xpath of the pop-up that appears when connecting to the chatgpt site for the first time has been changed, and that part has been added to chatgpt_data.py.